### PR TITLE
Allow user to turn off syncronization of device and sensor names from Telldus Live

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ ImportTelldusLive.prototype.init = function (config) {
     this.lastRequestS = 0;
     this.timerD = null; //Device Timer
     this.timerS = null; //Sensor Timer
+    this.alwaysSyncTitlesFromTelldus = this.config.alwaysSyncTitlesFromTelldus;
 
     //Init oAuth
     this.oauth = OAuth({
@@ -167,7 +168,10 @@ ImportTelldusLive.prototype.parseDeviceResponse = function (response) {
             var icon = (item.methods === 19) ? "multilevel" : "switch";
 
             if (vDev) {
-                vDev.set("metrics:title", "TL " + item.name); //Update title
+                if (self.alwaysSyncTitlesFromTelldus) {
+                    vDev.set("metrics:title", "TL " + item.name); //Update title
+                }
+
                 if (vDev.get("metrics:level") !== level) { //Only change if the level if different (or triggers will go haywire)
                     vDev.set("metrics:level", level);
                 }
@@ -402,7 +406,10 @@ ImportTelldusLive.prototype.parseSensorResponse = function (response) {
                         vDev = self.controller.devices.get(localId);
 
                 if (vDev) {
-                    vDev.set("metrics:title", "TL " + item.name + " " + sensorData.name); //Update title
+                    if (self.alwaysSyncTitlesFromTelldus) {
+                        vDev.set("metrics:title", "TL " + item.name + " " + sensorData.name); //Update title
+                    }
+        
                     vDev.set("updateTime", sensorData.lastUpdated);
                     if (vDev.get("metrics:level") !== sensorData.value) { //Only change if the level if different (or triggers will go haywire)
                         vDev.set("metrics:level", sensorData.value);

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,6 +8,7 @@
     "l_tokenSecret": "Token Secret",
     "l_dT":"Update period for Devices (in milliseconds)",
     "l_sT":"Update period for Sensors (in milliseconds)",
+    "l_alwaysSyncTitlesFromTelldus":"Always sync titles from Telldus (thus overriding changes made in Z-Way)",
     "l_urlEmonCMS":"URL to your EmonCMS installation for logging of sensor values",
     "l_apiKeyEmonCMS":"Write API Key of EmonCMS",
     "l_skipDevices": "List of devices not to import from remote side",

--- a/module.json
+++ b/module.json
@@ -22,6 +22,7 @@
         "tokenSecret": "",
         "dT": 60000,
         "sT": 300000,
+        "alwaysSyncTitlesFromTelldus": true,
         "urlEmonCMS": "",
         "apiKeyEmonCMS": "",
         "skipDevices": [],
@@ -57,6 +58,9 @@
             "sT": {
                 "type": "number",
                 "required": true
+            },
+            "alwaysSyncTitlesFromTelldus": {
+                "type": "boolean"
             },
             "urlEmonCMS": {
                 "type": "string",
@@ -117,6 +121,9 @@
             },
             "sT": {
                 "label": "__l_sT__"
+            },
+            "alwaysSyncTitlesFromTelldus": {
+                "label": "__l_alwaysSyncTitlesFromTelldus__"
             },
             "urlEmonCMS": {
                 "label": "__l_urlEmonCMS__"


### PR DESCRIPTION
Previous behavior was to always override any title changes made in Z-Way with the title from Telldus Live.

Fixes xibriz/ImportTelldusLive#1